### PR TITLE
Fix up unified/xast based parser

### DIFF
--- a/src/pmdToPtx.js
+++ b/src/pmdToPtx.js
@@ -5,76 +5,91 @@ import { toXml } from "xast-util-to-xml";
 import { CONTINUE, SKIP, visit } from "unist-util-visit";
 
 
+const inlineTags = ['em', 'alert', 'term', 'c', 'm', 'pretext', 'latex', 'tex', 'me', 'md', 'men', 'mdn', 'xref', 'fn',];
+const avoidPTags = ['p', 'caption', 'title', 'subtitle', 'idx', 'h'];
+
 export function pmdToPtx(pmdText) {
     // Remove the xml declaration if present
     pmdText = pmdText.replace(/<\?xml.*?\?>\s*/g, '');
 
+    // Fix '<' and '&' in math.
     pmdText = sanitizeMathXml(pmdText);
 
     console.log("Sanitized PMD text:", pmdText);
+    // Create a xast tree from the PMD text, wrapped in a root node.
+    // The 'root' node is necessary in case the PMD text has multiple top-level nodes.
     let tree = fromXml(`<root>${pmdText}</root>`);
 
     console.log("Initial tree:", tree);
+
+    // Traverse the tree and convert text nodes containing latex or markdown to PreTeXt
     visit(tree, (node, index, parent) => {
-        // If children contain any node of type text, reassemble the entire node and convert it:
-        if (node.children && node.children.some(child => child.type === "text" && !onlyWhiteSpace(child.value))) {
-            console.log("Node with text children found:", JSON.stringify(node, null, 2));
-            let content = toXml(node, { closeEmptyElements: true });
-            console.log("Reassembled content:", content);
-            content = content.replace(/<root>/g, '').replace(/<\/root>/g, '');
-            const convertedContent = fmToPTX(content);
-            console.log("Converted content:", convertedContent);
-            let convertedTree = fromXml(`<root>${convertedContent}</root>`);
+        // If node is text and contains non-whitespace characters, convert if necessary.  Then place converted as xml into tree and skip further processing of children.
+        // Note: we assume that the text node already contains all inline pretext markup, since the parent will have merged all of these.
+        if (node.type === "text" && !onlyWhiteSpace(node.value)) {
+            console.log("Processing text node:", node.value);
+            const convertedText = fmToPTX(node.value);
+            console.log("Converted text:", convertedText);
+
+            // If parent is a tag that contains text NOT in a <p> tag, strip current <p> tags.
+            let finalConvertedText = convertedText;
+            if (parent && parent.type === "element" && avoidPTags.includes(parent.name)) {
+                finalConvertedText = convertedText.replace(/<p>\s*/g, '').replace(/\s*<\/p>/g, '');
+                console.log("Stripped <p> tags for parent <p>:", convertedText, finalConvertedText);
+            }
+
+            // insert converted xml text as raw xml nodes
+            let convertedTree = fromXml(`<root>${finalConvertedText}</root>`);
+
             parent.children.splice(index, 1, ...convertedTree.children);
+            console.log("Parent after insertion:", JSON.stringify(parent, null, 2));
             return SKIP;
-            // Handle nodes with text children
         }
 
-        //if (node.type === "text" && !onlyWhiteSpace(node.value)) {
-        //console.log("text node is", node.value);
-        //console.log("parent is", parent);
-        //console.log("index is", index);
-        //console.log(`only whitespace? ${onlyWhiteSpace(node.value)}`);
-        //const convertedText = fmToPTX(node.value);
 
-        //console.log("converted text is", convertedText);
-
-        //// insert converted xml text as raw xml nodes
-        //let convertedTree = fromXml(`<root>${convertedText}</root>`);
-
-        //parent.children.splice(index, 1, ...convertedTree.children);
-        //return SKIP;
-        //}
+        // If children contain any node of type text, merge inline tags as text with their neighbors.  At the next level of the tree, these will be processed as text nodes.  This allows us to preserve the original inline markup.
+        if (node.children && node.children.some(child => child.type === "text" && !onlyWhiteSpace(child.value))) {
+            console.log("Node with text children found:", JSON.stringify(node, null, 2));
+            // Transform inline tags back into text nodes
+            node.children = node.children.reduce((acc, child) => {
+                if (child.type === "element" && (inlineTags.includes(child.name))) {
+                    let content = toXml(child, { closeEmptyElements: true });
+                    console.log("Reassembled content for", child.name, ":", content);
+                    // Merge with previous text node if possible
+                    if (acc.length > 0 && acc[acc.length - 1].type === "text") {
+                        acc[acc.length - 1].value += content;
+                    } else {
+                        acc.push({ type: "text", value: content });
+                    }
+                } else if (child.type === "text") {
+                    // Merge consecutive text nodes
+                    if (acc.length > 0 && acc[acc.length - 1].type === "text") {
+                        acc[acc.length - 1].value += child.value;
+                    } else {
+                        acc.push(child);
+                    }
+                } else {
+                    acc.push(child);
+                }
+                return acc;
+            }, []);
+            console.log("Transformed children:", JSON.stringify(node.children, null, 2));
+        }
     });
-
-    // Implement the conversion logic from PMD to PTX
-
-    // traverse tree and replace any <root> elements with their children
-    //console.log("Tree before removing root:", JSON.stringify(tree, null, 2));
-    //visit(tree, (node, index, parent) => {
-    //    if (node.name === "root" && parent) {
-    //        parent.children.splice(index, 1, ...node.children);
-    //        return SKIP;
-    //    }
-    //});
-    //console.log("Tree after removing root:", JSON.stringify(tree, null, 2));
 
     //let ptxText = fmToPTX(tree);
     let ptxText = toXml(tree, { closeEmptyElements: true });
     console.log("Final PTX text:", ptxText);
-    // clean up encoded characters
-    //ptxText = ptxText.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
-    // Remove the added root element
     ptxText = ptxText.replace(/<root>/g, '').replace(/<\/root>/g, '');
     console.log("PTX text after removing root:", ptxText);
     return ptxText;
 }
 
+// Utility to show tree as JSON on test page.
 export function pmdToXast(pmdText) {
     // Remove the xml declaration if present
     pmdText = pmdText.replace(/<\?xml.*?\?>\s*/g, '');
     pmdText = sanitizeMathXml(pmdText);
-
 
     let tree = fromXml(`<root>${pmdText}</root>`);
     return JSON.stringify(tree, null, 2);

--- a/src/pmdToPtx.js
+++ b/src/pmdToPtx.js
@@ -5,7 +5,7 @@ import { toXml } from "xast-util-to-xml";
 import { CONTINUE, SKIP, visit } from "unist-util-visit";
 
 
-const inlineTags = ['em', 'alert', 'term', 'c', 'm', 'pretext', 'latex', 'tex', 'me', 'md', 'men', 'mdn', 'xref', 'fn',];
+const inlineTags = ['em', 'alert', 'term', 'c', 'm', 'pretext', 'latex', 'tex', 'me', 'md', 'men', 'mdn', 'xref', 'fn', 'tag', 'attr'];
 const avoidPTags = ['p', 'caption', 'title', 'subtitle', 'idx', 'h'];
 
 export function pmdToPtx(pmdText) {


### PR DESCRIPTION
This gets the xast/unified parser mostly working.  I think that using this will greatly simplify the work of the main pretext markdown converter.  Here is the idea:

1. If the input contains xml tags, then we create a tree based on that xml.
2. The tree will contain a combination of "element" nodes, corresponding to tags, and "text" nodes corresponding to text.  
3. For every element node, we check whether any of its children are text nodes.  If so, then we look for children that are "inline" elements (`<m>`, `<term>` etc) and merge them, as text, with their neighboring siblings.
4. Then, when we get to these merged text nodes, we process them with the original converter, which spits out xml as text.  We put that xml (as xml) into the tree at that point, and don't process any of its children.
  - One exception: if the parent is a tag that shouldn't contain `<p>` tags itself, we strip those.  This will avoid nested `<p>` and `<p>` inside things like `<title>`.
5. Finally, we convert the final tree back into text.

You can play around with this using `npm run dev` and selecting the XAST-based converter from the drop-down.

There are likely inline tags I have missed, as well as the "avoidPTags" list.

Potential advantages:   No more worrying about whether the XML is being chunked correctly.  For example, with the original converter, strange things happen with `<image source="foo.png" width="10%">` (the attributes are repeated many times).  Since that is just an xml tag, this just works thanks to the `fromXML` function.   I tried to find where this bug appeared, but the parsing is complicated.  If we can limit the original converter to just dealing with MD and LaTeX tags, that will make it easier to maintain I think.